### PR TITLE
implement and register DepthGuesser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-* **2016-04-12**: Build and register DepthGuesser for PHPCR to use depths information for structure sitemap
+* **2016-04-12**: Build and register DepthGuesser for PHPCR to use depths information for structure sitemap 
 
 1.2.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* **2016-04-12**: Build and register DepthGuesser for PHPCR to use depths information for structure sitemap
+
 1.2.0
 -----
 

--- a/Doctrine/Phpcr/SitemapDocumentProvider.php
+++ b/Doctrine/Phpcr/SitemapDocumentProvider.php
@@ -42,7 +42,7 @@ class SitemapDocumentProvider implements LoaderInterface
     {
         // todo rewrite query when https://github.com/symfony-cmf/CoreBundle/issues/126 is ready
         $documentsCollection = $this->manager->createQuery(
-            'SELECT * FROM [nt:unstructured] WHERE (visible_for_sitemap = true)',
+            'SELECT * FROM [nt:unstructured] WHERE (visible_for_sitemap = true) ORDER By id',
             QueryInterface::JCR_SQL2
         )->execute();
 

--- a/Doctrine/Phpcr/SitemapDocumentProvider.php
+++ b/Doctrine/Phpcr/SitemapDocumentProvider.php
@@ -42,7 +42,7 @@ class SitemapDocumentProvider implements LoaderInterface
     {
         // todo rewrite query when https://github.com/symfony-cmf/CoreBundle/issues/126 is ready
         $documentsCollection = $this->manager->createQuery(
-            'SELECT * FROM [nt:unstructured] WHERE (visible_for_sitemap = true) ORDER By id',
+            'SELECT * FROM [nt:unstructured] WHERE (visible_for_sitemap = true) ORDER By [jcr:path]',
             QueryInterface::JCR_SQL2
         )->execute();
 

--- a/Model/UrlInformation.php
+++ b/Model/UrlInformation.php
@@ -60,6 +60,11 @@ class UrlInformation
      */
     private $alternateLocales;
 
+    /**
+     * @var int
+     */
+    private $depth;
+
     public function __construct()
     {
         $this->alternateLocales = array();
@@ -94,6 +99,7 @@ class UrlInformation
             'lastmod' => $this->lastModification,
             'priority' => $this->priority,
             'alternate_locales' => array(),
+            'depth' => $this->depth,
         );
         foreach ($result as $key => $value) {
             if (null === $value) {
@@ -247,5 +253,21 @@ class UrlInformation
         $this->alternateLocales[] = $alternateLocale;
 
         return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDepth()
+    {
+        return $this->depth;
+    }
+
+    /**
+     * @param int $depth
+     */
+    public function setDepth($depth)
+    {
+        $this->depth = $depth;
     }
 }

--- a/Model/UrlInformation.php
+++ b/Model/UrlInformation.php
@@ -61,7 +61,7 @@ class UrlInformation
     private $alternateLocales;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $depth;
 
@@ -264,7 +264,7 @@ class UrlInformation
     }
 
     /**
-     * @param int $depth
+     * @param int|null $depth
      */
     public function setDepth($depth)
     {

--- a/Resources/config/phpcr-sitemap.xml
+++ b/Resources/config/phpcr-sitemap.xml
@@ -15,5 +15,11 @@
 
             <tag name="cmf_seo.sitemap.loader" priority="-2"/>
         </service>
+        <service id="cmf_seo.sitemap.phpcr.depth_guesser" class="Symfony\Cmf\Bundle\SeoBundle\Sitemap\DepthGuesser">
+            <argument type="service" id="doctrine_phpcr"/>
+            <argument>%cmf_routing.dynamic.persistence.phpcr.content_basepath%</argument>
+
+            <tag name="cmf_seo.sitemap.guesser" position="-2"/>
+        </service>
     </services>
 </container>

--- a/Resources/views/Sitemap/index.html.twig
+++ b/Resources/views/Sitemap/index.html.twig
@@ -1,7 +1,7 @@
 <ul class="cmf-sitemap">
     {% for url in urls %}
         <li>
-            <a href="{{ url.location }}" title="{{ url.label }}">{{ url.label }}</a>
+            {% if url.depth is not null %} <span class="indent-{{ url.depth }}"></span>{% endif %}<a href="{{ url.location }}" title="{{ url.label }}">{{ url.label }}</a>
         </li>
     {% endfor %}
 </ul>

--- a/Resources/views/Sitemap/index.html.twig
+++ b/Resources/views/Sitemap/index.html.twig
@@ -1,7 +1,7 @@
 <ul class="cmf-sitemap">
     {% for url in urls %}
-        <li>
-            {% if url.depth is not null %} <span class="indent-{{ url.depth }}"></span>{% endif %}<a href="{{ url.location }}" title="{{ url.label }}">{{ url.label }}</a>
+        <li{% if url.depth is not null %} class="indent-{{ url.depth }}"{% endif %}>
+            <a href="{{ url.location }}" title="{{ url.label }}">{{ url.label }}</a>
         </li>
     {% endfor %}
 </ul>

--- a/Sitemap/DepthGuesser.php
+++ b/Sitemap/DepthGuesser.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Cmf\Bundle\SeoBundle\Sitemap;
 
 use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;

--- a/Sitemap/DepthGuesser.php
+++ b/Sitemap/DepthGuesser.php
@@ -40,8 +40,7 @@ class DepthGuesser implements GuesserInterface
     public function __construct(ManagerRegistry $managerRegistry, $contentBasePath)
     {
         $this->managerRegistry = $managerRegistry;
-        $exploded = explode('/', $contentBasePath);
-        $this->offset = count($exploded);
+        $this->offset = substr_count($contentBasePath, '/') + 1;
     }
 
     /**

--- a/Tests/Functional/Doctrine/Phpcr/SitemapDocumentProviderTest.php
+++ b/Tests/Functional/Doctrine/Phpcr/SitemapDocumentProviderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Functional\Doctrine\Phpcr;
+
+use Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\SitemapDocumentProvider;
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class SitemapDocumentProviderTest extends BaseTestCase
+{
+    /**
+     * @var SitemapDocumentProvider
+     */
+    private $documentProvider;
+
+    public function setUp()
+    {
+        $this->db('PHPCR')->createTestNode();
+        $this->dm = $this->db('PHPCR')->getOm();
+        $this->base = $this->dm->find(null, '/test');
+        $this->db('PHPCR')->loadFixtures(array(
+            'Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\DataFixtures\Phpcr\LoadSitemapData',
+        ));
+
+        $this->documentProvider = new SitemapDocumentProvider($this->dm);
+    }
+
+    public function testDocumentOrder()
+    {
+        $documents = $this->documentProvider->load('default');
+
+        $paths = array();
+        foreach ($documents as $document) {
+            $paths[] = $document->getId();
+        }
+
+        $this->assertEquals(
+            array(
+                '/test/content/sitemap-aware',
+                '/test/content/sitemap-aware-non-publish',
+                '/test/content/sitemap-aware-publish',
+            ),
+            $paths
+        );
+    }
+}

--- a/Tests/Unit/Sitemap/DepthGuesserTest.php
+++ b/Tests/Unit/Sitemap/DepthGuesserTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Sitemap;
+
+use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use PHPCR\NodeInterface;
+use Symfony\Cmf\Bundle\SeoBundle\Model\UrlInformation;
+use Symfony\Cmf\Bundle\SeoBundle\Sitemap\DepthGuesser;
+use Symfony\Cmf\Bundle\SeoBundle\Sitemap\GuesserInterface;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class DepthGuesserTest extends GuesserTestCase
+{
+    /**
+     * @var \stdClass
+     */
+    protected $object;
+
+    /**
+     * @var ManagerRegistry
+     */
+    protected $managerRegistry;
+
+    /**
+     * @var DocumentManager
+     */
+    protected $documentManager;
+
+    /**
+     * @var DepthGuesser
+     */
+    protected $guesser;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $node;
+
+    /**
+     * Create the guesser for this test.
+     *
+     * @return GuesserInterface
+     */
+    protected function createGuesser()
+    {
+        $this->buildMocks();
+
+        $this->managerRegistry
+            ->expects($this->any())
+            ->method('getManagerForClass')
+            ->with(get_class($this->object))
+            ->will($this->returnValue($this->documentManager));
+        $this->documentManager
+            ->expects($this->any())
+            ->method('getNodeForDocument')
+            ->with($this->object)
+            ->willReturn($this->node);
+        $this->node
+            ->expects($this->any())
+            ->method('getDepth')
+            ->will($this->returnValue(3));
+
+        return $this->guesser;
+    }
+
+    /**
+     * @return object
+     */
+    protected function createData()
+    {
+        return $this->object;
+    }
+
+    /**
+     * Provide list of fields in UrlInformation covered by this guesser.
+     *
+     * @return array
+     */
+    protected function getFields()
+    {
+        return array('depth');
+    }
+
+    /**
+     * Method to extract mock building.
+     */
+    private function buildMocks()
+    {
+        $this->managerRegistry = $this->getMockBuilder('Doctrine\Bundle\PHPCRBundle\ManagerRegistry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->documentManager = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->node = $this->getMock('PHPCR\NodeInterface');
+        $this->object = new \stdClass();
+        $this->guesser = new DepthGuesser($this->managerRegistry, '/cms/test');
+    }
+
+    public function testNullOnNoManager()
+    {
+        $this->buildMocks();
+        $this->managerRegistry
+            ->expects($this->any())
+            ->method('getManagerForClass')
+            ->with(get_class($this->object))
+            ->will($this->returnValue(null));
+        $urlInformation = new UrlInformation();
+        $this->guesser->guessValues($urlInformation, $this->object, 'default');
+
+        $this->assertNull($urlInformation->getDepth());
+    }
+
+    public function testDepthOffsetCalculation()
+    {
+        $this->buildMocks();
+
+        $this->managerRegistry
+            ->expects($this->any())
+            ->method('getManagerForClass')
+            ->with(get_class($this->object))
+            ->will($this->returnValue($this->documentManager));
+        $this->documentManager
+            ->expects($this->any())
+            ->method('getNodeForDocument')
+            ->with($this->object)
+            ->willReturn($this->node);
+        $this->node
+            ->expects($this->any())
+            ->method('getDepth')
+            ->will($this->returnValue(4));
+        $urlInformation = new UrlInformation();
+        $this->guesser->guessValues($urlInformation, $this->object, 'default');
+
+        $this->assertEquals(1, $urlInformation->getDepth());
+    }
+}

--- a/Tests/Unit/Sitemap/DepthGuesserTest.php
+++ b/Tests/Unit/Sitemap/DepthGuesserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Sitemap;
 
 use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;

--- a/Tests/WebTest/SitemapTest.php
+++ b/Tests/WebTest/SitemapTest.php
@@ -70,10 +70,10 @@ class SitemapTest extends BaseTestCase
                 'html',
                 '<ul class="cmf-sitemap">
                     <li>
-                        <a href="http://localhost/sitemap-aware" title="Sitemap Aware Content">Sitemap Aware Content</a>
+                        <span class="indent-0"></span><a href="http://localhost/sitemap-aware" title="Sitemap Aware Content">Sitemap Aware Content</a>
                     </li>
                     <li>
-                        <a href="http://localhost/sitemap-aware-publish" title="Sitemap Aware Content publish">Sitemap Aware Content publish</a>
+                        <span class="indent-0"></span><a href="http://localhost/sitemap-aware-publish" title="Sitemap Aware Content publish">Sitemap Aware Content publish</a>
                     </li>
                 </ul>',
             ),
@@ -94,7 +94,7 @@ class SitemapTest extends BaseTestCase
             ),
             array(
                 'json',
-                '[{"loc":"http:\/\/localhost\/sitemap-aware","label":"Sitemap Aware Content","changefreq":"never","alternate_locales":[{"href":"http:\/\/localhost\/sitemap-aware?_locale=de","href_locale":"de"}]},{"loc":"http:\/\/localhost\/sitemap-aware-publish","label":"Sitemap Aware Content publish","changefreq":"never","alternate_locales":[]}]',
+                '[{"loc":"http:\/\/localhost\/sitemap-aware","label":"Sitemap Aware Content","changefreq":"never","alternate_locales":[{"href":"http:\/\/localhost\/sitemap-aware?_locale=de","href_locale":"de"}],"depth":0},{"loc":"http:\/\/localhost\/sitemap-aware-publish","label":"Sitemap Aware Content publish","changefreq":"never","alternate_locales":[],"depth":0}]',
             ),
         );
     }

--- a/Tests/WebTest/SitemapTest.php
+++ b/Tests/WebTest/SitemapTest.php
@@ -69,11 +69,11 @@ class SitemapTest extends BaseTestCase
             array(
                 'html',
                 '<ul class="cmf-sitemap">
-                    <li>
-                        <span class="indent-0"></span><a href="http://localhost/sitemap-aware" title="Sitemap Aware Content">Sitemap Aware Content</a>
+                    <li class="indent-0">
+                        <a href="http://localhost/sitemap-aware" title="Sitemap Aware Content">Sitemap Aware Content</a>
                     </li>
-                    <li>
-                        <span class="indent-0"></span><a href="http://localhost/sitemap-aware-publish" title="Sitemap Aware Content publish">Sitemap Aware Content publish</a>
+                    <li class="indent-0">
+                        <a href="http://localhost/sitemap-aware-publish" title="Sitemap Aware Content publish">Sitemap Aware Content publish</a>
                     </li>
                 </ul>',
             ),

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "1.3-dev"
         }
     }
 }


### PR DESCRIPTION
This PR will implement a solution to implement #280 I did that by adding a so called `DepthGuesser` for enabled phpcr. The depth is 0 for the first entry on content_basepath. So a content on  `/cms/content/test` with basepath `/cms/content` will get a 0 as result. The first ones will get no indend in the html template doing it that way.

btw: i miss the nice and helpfull PR template in the guidelines, which i have copied every time.