### PR TITLE
add github template from symfony

### DIFF
--- a/.github/PULL_REQUEST_TEMPLAE.md
+++ b/.github/PULL_REQUEST_TEMPLAE.md
@@ -1,0 +1,11 @@
+| Q             | A
+| ------------- | ---
+| Branch?       | "master" for new features / 1.0, 1.1, 1.2, 1.3, 1.4 for fixes
+| Bug fix?      | yes/no
+| New feature?  | yes/no
+| BC breaks?    | yes/no
+| Deprecations? | yes/no
+| Tests pass?   | yes/no
+| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
+| License       | MIT
+| Doc PR        | reference to the documentation PR, if any

--- a/.github/PULL_REQUEST_TEMPLAE.md
+++ b/.github/PULL_REQUEST_TEMPLAE.md
@@ -1,11 +1,10 @@
 | Q             | A
 | ------------- | ---
-| Branch?       | "master" for new features / 1.0, 1.1, 1.2, 1.3, 1.4 for fixes
+| Branch?       | "master" for new features / the branch of the current release for fixes
 | Bug fix?      | yes/no
 | New feature?  | yes/no
 | BC breaks?    | yes/no
 | Deprecations? | yes/no
-| Tests pass?   | yes/no
 | Fixed tickets | comma-separated list of tickets fixed by the PR, if any
 | License       | MIT
 | Doc PR        | reference to the documentation PR, if any


### PR DESCRIPTION
I just picked the symfony template as they are very close to us. Started here and will add them everywhere when we are fine with that. Should we add a notice to the contribution guidelines?

Information: https://github.com/blog/2111-issue-and-pull-request-templates