### PR TITLE
do not depend on the routing bundle for content basepath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   matrix: SYMFONY_VERSION=3.2.*
   global:
     - SYMFONY_DEPRECATIONS_HELPER=48
-    - SYMFONY_PHPUNIT_DIR=.phpunit SYMFONY_PHPUNIT_REMOVE="symfony/yaml"
+    - SYMFONY_PHPUNIT_DIR=.phpunit SYMFONY_PHPUNIT_REMOVE="symfony/yaml" SYMFONY_PHPUNIT_VERSION=5.7
 
 matrix:
   include:

--- a/src/DependencyInjection/CmfSeoExtension.php
+++ b/src/DependencyInjection/CmfSeoExtension.php
@@ -66,6 +66,10 @@ class CmfSeoExtension extends Extension
                 'cmf_seo.persistence.phpcr.manager_name',
                 $config['persistence']['phpcr']['manager_name']
             );
+            $container->setParameter(
+                'cmf_seo.persistence.phpcr.content_basepath',
+                $config['persistence']['phpcr']['content_basepath']
+            );
             $sonataBundles[] = 'SonataDoctrinePHPCRAdminBundle';
 
             $this->loadPhpcr($config['persistence']['phpcr'], $loader, $container);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -111,6 +111,7 @@ class Configuration implements ConfigurationInterface
                         ->canBeEnabled()
                         ->children()
                             ->scalarNode('manager_name')->defaultNull()->end()
+                            ->scalarNode('content_basepath')->defaultValue('/cms/content')->end()
                         ->end()
                     ->end()
 

--- a/src/Resources/config/phpcr-sitemap.xml
+++ b/src/Resources/config/phpcr-sitemap.xml
@@ -13,7 +13,7 @@
         </service>
         <service id="cmf_seo.sitemap.phpcr.depth_guesser" class="Symfony\Cmf\Bundle\SeoBundle\Sitemap\DepthGuesser">
             <argument type="service" id="doctrine_phpcr"/>
-            <argument>%cmf_routing.dynamic.persistence.phpcr.content_basepath%</argument>
+            <argument>%cmf_seo.persistence.phpcr.content_basepath%</argument>
 
             <tag name="cmf_seo.sitemap.guesser" position="-2"/>
         </service>

--- a/tests/Unit/Controller/SitemapControllerTest.php
+++ b/tests/Unit/Controller/SitemapControllerTest.php
@@ -40,16 +40,13 @@ class SitemapControllerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->provider = $this
-            ->getMockBuilder('Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProvider')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->provider = $this->createMock(UrlInformationProvider::class);
         $this->provider
             ->expects($this->any())
             ->method('getUrlInformation')
             ->will($this->returnValue($this->createUrlInformation()));
 
-        $this->templating = $this->getMock('Symfony\Component\Templating\EngineInterface');
+        $this->templating = $this->createMock(EngineInterface::class);
         $this->controller = new SitemapController(
             $this->provider,
             $this->templating,

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -44,6 +44,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'phpcr' => [
                     'enabled' => false,
                     'manager_name' => null,
+                    'content_basepath' => '/cms/content',
                 ],
                 'orm' => [
                     'enabled' => false,
@@ -127,6 +128,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'phpcr' => [
                     'enabled' => false,
                     'manager_name' => null,
+                    'content_basepath' => '/cms/content',
                 ],
                 'orm' => [
                     'enabled' => false,
@@ -192,6 +194,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'phpcr' => [
                     'enabled' => false,
                     'manager_name' => null,
+                    'content_basepath' => '/cms/content',
                 ],
                 'orm' => [
                     'enabled' => false,

--- a/tests/Unit/EventListener/ContentListenerTest.php
+++ b/tests/Unit/EventListener/ContentListenerTest.php
@@ -13,6 +13,11 @@ namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\EventListener;
 
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
 use Symfony\Cmf\Bundle\SeoBundle\EventListener\ContentListener;
+use Symfony\Cmf\Bundle\SeoBundle\SeoPresentationInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 class ContentListenerTest extends \PHPUnit_Framework_Testcase
 {
@@ -23,11 +28,9 @@ class ContentListenerTest extends \PHPUnit_Framework_Testcase
 
     public function setUp()
     {
-        $this->seoPresentation = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\SeoPresentationInterface');
-        $this->request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $this->event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->seoPresentation = $this->createMock(SeoPresentationInterface::class);
+        $this->request = $this->createMock(Request::class);
+        $this->event = $this->createMock(GetResponseEvent::class);
         $this->listener = new ContentListener($this->seoPresentation, DynamicRouter::CONTENT_KEY);
     }
 
@@ -36,9 +39,7 @@ class ContentListenerTest extends \PHPUnit_Framework_Testcase
      */
     public function testRedirectRoute($targetUrl, $redirect = true, $currentPath = '/test')
     {
-        $redirectResponse = $this->getMockBuilder('Symfony\Component\HttpFoundation\RedirectResponse')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $redirectResponse = $this->createMock(RedirectResponse::class);
         $redirectResponse->expects($this->any())
             ->method('getTargetUrl')
             ->will($this->returnValue($targetUrl));
@@ -73,7 +74,7 @@ class ContentListenerTest extends \PHPUnit_Framework_Testcase
             ;
         }
 
-        $attributes = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $attributes = $this->createMock(ParameterBag::class);
         $attributes
             ->expects($this->any())
             ->method('has')

--- a/tests/Unit/EventListener/LanguageListenerTest.php
+++ b/tests/Unit/EventListener/LanguageListenerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\EventListener;
 use Symfony\Cmf\Bundle\SeoBundle\EventListener\LanguageListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 class LanguageListenerTest extends \PHPUnit_Framework_Testcase
 {
@@ -34,7 +35,7 @@ class LanguageListenerTest extends \PHPUnit_Framework_Testcase
 
         $response = new Response();
 
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\FilterResponseEvent')->disableOriginalConstructor()->getMock();
+        $event = $this->createMock(FilterResponseEvent::class);
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
 
@@ -59,7 +60,7 @@ class LanguageListenerTest extends \PHPUnit_Framework_Testcase
         $response = new Response();
         $response->headers->set('Content-Language', 'nl');
 
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\FilterResponseEvent')->disableOriginalConstructor()->getMock();
+        $event = $this->createMock(FilterResponseEvent::class);
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
 

--- a/tests/Unit/Extractor/BaseTestCase.php
+++ b/tests/Unit/Extractor/BaseTestCase.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Extractor;
 
+use Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadataInterface;
+
 abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
 {
     protected $seoMetadata;
@@ -22,7 +24,7 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->seoMetadata = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadataInterface');
+        $this->seoMetadata = $this->createMock(SeoMetadataInterface::class);
     }
 
     /**
@@ -43,7 +45,7 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
 
     public function testExtracting()
     {
-        $document = $this->getMock('ExtractedDocument', [$this->extractMethod]);
+        $document = $this->getMockBuilder('ExtractedDocument')->setMethods([$this->extractMethod])->getMock();
         $document->expects($this->any())
             ->method($this->extractMethod)
             ->will($this->returnValue('extracted'));

--- a/tests/Unit/Extractor/DescriptionExtractorTest.php
+++ b/tests/Unit/Extractor/DescriptionExtractorTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Extractor;
 
 use Symfony\Cmf\Bundle\SeoBundle\Extractor\DescriptionExtractor;
+use Symfony\Cmf\Bundle\SeoBundle\Extractor\DescriptionReadInterface;
+use Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface;
 
 class DescriptionExtractorTest extends BaseTestCase
 {
@@ -27,8 +29,8 @@ class DescriptionExtractorTest extends BaseTestCase
     public function getSupportsData()
     {
         return [
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\DescriptionReadInterface')],
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface'), false],
+            [$this->createMock(DescriptionReadInterface::class)],
+            [$this->createMock(SeoAwareInterface::class), false],
         ];
     }
 }

--- a/tests/Unit/Extractor/ExtrasExtractorTest.php
+++ b/tests/Unit/Extractor/ExtrasExtractorTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Extractor;
 
 use Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtrasExtractor;
+use Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtrasReadInterface;
+use Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface;
 
 class ExtrasExtractorTest extends BaseTestCase
 {
@@ -25,14 +27,14 @@ class ExtrasExtractorTest extends BaseTestCase
     public function getSupportsData()
     {
         return [
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtrasReadInterface')],
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\Model\SeoAwareInterface'), false],
+            [$this->createMock(ExtrasReadInterface::class)],
+            [$this->createMock(SeoAwareInterface::class), false],
         ];
     }
 
     public function testExtracting()
     {
-        $document = $this->getMock('ExtractedDocument', ['getSeoExtras']);
+        $document = $this->getMockBuilder('ExtractedDocument')->setMethods(['getSeoExtras'])->getMock();
         $document->expects($this->any())
             ->method('getSeoExtras')
             ->will($this->returnValue([

--- a/tests/Unit/Extractor/KeywordsExtractorTest.php
+++ b/tests/Unit/Extractor/KeywordsExtractorTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Extractor;
 
 use Symfony\Cmf\Bundle\SeoBundle\Extractor\KeywordsExtractor;
+use Symfony\Cmf\Bundle\SeoBundle\Extractor\KeywordsReadInterface;
+use Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface;
 
 class KeywordsExtractorTest extends BaseTestCase
 {
@@ -27,8 +29,8 @@ class KeywordsExtractorTest extends BaseTestCase
     public function getSupportsData()
     {
         return [
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\KeywordsReadInterface')],
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface'), false],
+            [$this->createMock(KeywordsReadInterface::class)],
+            [$this->createMock(SeoAwareInterface::class), false],
         ];
     }
 }

--- a/tests/Unit/Extractor/OriginalRouteExtractorTest.php
+++ b/tests/Unit/Extractor/OriginalRouteExtractorTest.php
@@ -12,6 +12,9 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Extractor;
 
 use Symfony\Cmf\Bundle\SeoBundle\Extractor\OriginalRouteExtractor;
+use Symfony\Cmf\Bundle\SeoBundle\Extractor\OriginalRouteReadInterface;
+use Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class OriginalRouteExtractorTest extends BaseTestCase
 {
@@ -21,7 +24,7 @@ class OriginalRouteExtractorTest extends BaseTestCase
     {
         parent::setUp();
 
-        $this->urlGenerator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $this->extractor = new OriginalRouteExtractor($this->urlGenerator);
         $this->extractMethod = 'getSeoOriginalRoute';
         $this->metadataMethod = 'setOriginalUrl';
@@ -30,8 +33,8 @@ class OriginalRouteExtractorTest extends BaseTestCase
     public function getSupportsData()
     {
         return [
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\OriginalRouteReadInterface')],
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface'), false],
+            [$this->createMock(OriginalRouteReadInterface::class)],
+            [$this->createMock(SeoAwareInterface::class), false],
         ];
     }
 

--- a/tests/Unit/Extractor/OriginalUrlExtractorTest.php
+++ b/tests/Unit/Extractor/OriginalUrlExtractorTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Extractor;
 
 use Symfony\Cmf\Bundle\SeoBundle\Extractor\OriginalUrlExtractor;
+use Symfony\Cmf\Bundle\SeoBundle\Extractor\OriginalUrlReadInterface;
+use Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface;
 
 class OriginalUrlExtractorTest extends BaseTestCase
 {
@@ -27,8 +29,8 @@ class OriginalUrlExtractorTest extends BaseTestCase
     public function getSupportsData()
     {
         return [
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\OriginalUrlReadInterface')],
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface'), false],
+            [$this->createMock(OriginalUrlReadInterface::class)],
+            [$this->createMock(SeoAwareInterface::class), false],
         ];
     }
 }

--- a/tests/Unit/Extractor/TitleExtractorTest.php
+++ b/tests/Unit/Extractor/TitleExtractorTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Extractor;
 
 use Symfony\Cmf\Bundle\SeoBundle\Extractor\TitleExtractor;
+use Symfony\Cmf\Bundle\SeoBundle\Extractor\TitleReadInterface;
+use Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface;
 
 class TitleExtractorTest extends BaseTestCase
 {
@@ -27,8 +29,8 @@ class TitleExtractorTest extends BaseTestCase
     public function getSupportsData()
     {
         return [
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\TitleReadInterface')],
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface'), false],
+            [$this->createMock(TitleReadInterface::class)],
+            [$this->createMock(SeoAwareInterface::class), false],
         ];
     }
 }

--- a/tests/Unit/Extractor/TitleReadExtractorTest.php
+++ b/tests/Unit/Extractor/TitleReadExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Extractor;
 
 use Symfony\Cmf\Bundle\SeoBundle\Extractor\TitleReadExtractor;
+use Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface;
 
 class TitleReadExtractorTest extends BaseTestCase
 {
@@ -27,8 +28,8 @@ class TitleReadExtractorTest extends BaseTestCase
     public function getSupportsData()
     {
         return [
-            [$this->getMock('Foo', ['getTitle'])],
-            [$this->getMock('Symfony\Cmf\Bundle\SeoBundle\SeoAwareInterface'), false],
+            [$this->getMockBuilder('Foo')->setMethods(['getTitle'])->getMock()],
+            [$this->createMock(SeoAwareInterface::class), false],
         ];
     }
 }

--- a/tests/Unit/Matcher/ExclusionMatcherTest.php
+++ b/tests/Unit/Matcher/ExclusionMatcherTest.php
@@ -35,8 +35,8 @@ class ExclusionMatcherTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->matcherA = $this->getMock('Symfony\Component\HttpFoundation\RequestMatcherInterface');
-        $this->matcherB = $this->getMock('Symfony\Component\HttpFoundation\RequestMatcherInterface');
+        $this->matcherA = $this->createMock(RequestMatcherInterface::class);
+        $this->matcherB = $this->createMock(RequestMatcherInterface::class);
 
         $this->exclusionMatcher = new ExclusionMatcher();
         $this->exclusionMatcher->addRequestMatcher($this->matcherA);

--- a/tests/Unit/SeoPresentationTest.php
+++ b/tests/Unit/SeoPresentationTest.php
@@ -11,9 +11,15 @@
 
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit;
 
+use Sonata\SeoBundle\Seo\SeoPage;
+use Symfony\Cmf\Bundle\SeoBundle\Cache\CacheInterface;
+use Symfony\Cmf\Bundle\SeoBundle\Cache\ExtractorCollection;
 use Symfony\Cmf\Bundle\SeoBundle\DependencyInjection\ConfigValues;
+use Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtractorInterface;
 use Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadataInterface;
 use Symfony\Cmf\Bundle\SeoBundle\SeoPresentation;
+use Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\SeoAwareContent;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * This test will cover the behavior of the SeoPresentation Model
@@ -31,8 +37,8 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
 
     public function setUp()
     {
-        $this->pageService = $this->getMock('Sonata\SeoBundle\Seo\SeoPage');
-        $this->translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $this->pageService = $this->createMock(SeoPage::class);
+        $this->translator = $this->createMock(TranslatorInterface::class);
         $this->configValues = new ConfigValues();
         $this->configValues->setDescription('default_description');
         $this->configValues->setTitle('default_title');
@@ -44,9 +50,9 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
             $this->configValues
         );
 
-        $this->seoMetadata = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadata');
+        $this->seoMetadata = $this->createMock(SeoMetadataInterface::class);
 
-        $this->content = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\SeoAwareContent');
+        $this->content = $this->createMock(SeoAwareContent::class);
         $this->content
             ->expects($this->any())
             ->method('getSeoMetadata')
@@ -185,7 +191,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
             ->method('trans')
             ->will($this->returnValue('translation strategy test'))
         ;
-        $extractor = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtractorInterface');
+        $extractor = $this->createMock(ExtractorInterface::class);
         $extractor
             ->expects($this->any())
             ->method('supports')
@@ -217,14 +223,14 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
             )
             ->will($this->returnValue('translation strategy test'))
         ;
-        $extractorDefault = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtractorInterface');
+        $extractorDefault = $this->createMock(ExtractorInterface::class);
         $extractorDefault
             ->expects($this->any())
             ->method('supports')
             ->with($this->content)
             ->will($this->returnValue(true))
         ;
-        $extractorOne = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtractorInterface');
+        $extractorOne = $this->createMock(ExtractorInterface::class);
         $extractorOne
             ->expects($this->any())
             ->method('supports')
@@ -268,14 +274,14 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
         ;
 
         // promises
-        $extractorDefault = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtractorInterface');
+        $extractorDefault = $this->createMock(ExtractorInterface::class);
         $extractorDefault
             ->expects($this->any())
             ->method('supports')
             ->with($this->content)
             ->will($this->returnValue(true))
         ;
-        $extractorOne = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Extractor\ExtractorInterface');
+        $extractorOne = $this->createMock(ExtractorInterface::class);
         $extractorOne
             ->expects($this->any())
             ->method('supports')
@@ -331,10 +337,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
 
     public function testCaching()
     {
-        // promises
-        $extractors = $this->getMockBuilder('Symfony\Cmf\Bundle\SeoBundle\Cache\ExtractorCollection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $extractors = $this->createMock(ExtractorCollection::class);
         $extractors
             ->expects($this->any())
             ->method('isFresh')
@@ -345,7 +348,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
             ->method('getIterator')
             ->will($this->returnValue(new \ArrayIterator()))
         ;
-        $cache = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Cache\CacheInterface');
+        $cache = $this->createMock(CacheInterface::class);
         $cache
             ->expects($this->any())
             ->method('loadExtractorsFromCache')
@@ -373,9 +376,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
     public function testCacheRefresh()
     {
         // promises
-        $extractors = $this->getMockBuilder('Symfony\Cmf\Bundle\SeoBundle\Cache\ExtractorCollection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $extractors = $this->createMock(ExtractorCollection::class);
         $extractors
             ->expects($this->any())
             ->method('isFresh')
@@ -386,7 +387,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
             ->method('getIterator')
             ->will($this->returnValue(new \ArrayIterator()))
         ;
-        $cache = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Cache\CacheInterface');
+        $cache = $this->createMock(CacheInterface::class);
         $cache
             ->expects($this->any())
             ->method('loadExtractorsFromCache')
@@ -412,7 +413,7 @@ class SeoPresentationTest extends \PHPUnit_Framework_Testcase
 
     public function testSeoAwareWithoutCurrentMetadata()
     {
-        $content = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\Document\SeoAwareContent');
+        $content = $this->createMock(SeoAwareContent::class);
         $content
             ->expects($this->any())
             ->method('getSeoMetadata')

--- a/tests/Unit/Sitemap/AlternateLocalesGuesserTest.php
+++ b/tests/Unit/Sitemap/AlternateLocalesGuesserTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Sitemap;
 
+use Symfony\Cmf\Bundle\SeoBundle\AlternateLocaleProviderInterface;
 use Symfony\Cmf\Bundle\SeoBundle\Model\AlternateLocale;
 use Symfony\Cmf\Bundle\SeoBundle\Model\AlternateLocaleCollection;
 use Symfony\Cmf\Bundle\SeoBundle\Sitemap\AlternateLocalesGuesser;
@@ -25,7 +26,7 @@ class AlternateLocalesGuesserTest extends GuesserTestCase
         $collection = new AlternateLocaleCollection();
         $collection->add(new AlternateLocale('http://symfony.com/fr', 'fr'));
 
-        $localeProvider = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\AlternateLocaleProviderInterface');
+        $localeProvider = $this->createMock(AlternateLocaleProviderInterface::class);
         $localeProvider
             ->expects($this->any())
             ->method('createForContent')

--- a/tests/Unit/Sitemap/DepthGuesserTest.php
+++ b/tests/Unit/Sitemap/DepthGuesserTest.php
@@ -100,13 +100,9 @@ class DepthGuesserTest extends GuesserTestCase
      */
     private function buildMocks($contentBasePath = '/cms/test')
     {
-        $this->managerRegistry = $this->getMockBuilder('Doctrine\Bundle\PHPCRBundle\ManagerRegistry')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->documentManager = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->node = $this->getMock('PHPCR\NodeInterface');
+        $this->managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->documentManager = $this->createMock(DocumentManager::class);
+        $this->node = $this->createMock(NodeInterface::class);
         $this->object = new \stdClass();
         $this->guesser = new DepthGuesser($this->managerRegistry, $contentBasePath);
     }

--- a/tests/Unit/Sitemap/LastModifiedGuesserTest.php
+++ b/tests/Unit/Sitemap/LastModifiedGuesserTest.php
@@ -51,9 +51,9 @@ class LastModifiedGuesserTest extends GuesserTestCase
      */
     protected function createGuesser()
     {
-        $this->registry = $this->getMockBuilder('\Doctrine\Bundle\PHPCRBundle\ManagerRegistry')->disableOriginalConstructor()->getMock();
-        $this->manager = $this->getMockBuilder('\Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
-        $this->metadata = $this->getMockBuilder('\Doctrine\ODM\PHPCR\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
+        $this->registry = $this->createMock(ManagerRegistry::class);
+        $this->manager = $this->createMock(DocumentManager::class);
+        $this->metadata = $this->createMock(ClassMetadata::class);
         $this->registry
             ->expects($this->any())
             ->method('getManagerForClass')

--- a/tests/Unit/Sitemap/LocationGuesserTest.php
+++ b/tests/Unit/Sitemap/LocationGuesserTest.php
@@ -27,7 +27,7 @@ class LocationGuesserTest extends GuesserTestCase
      */
     protected function createGuesser()
     {
-        $urlGenerator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator
             ->expects($this->any())
             ->method('generate')

--- a/tests/Unit/Sitemap/SeoMetadataTitleGuesserTest.php
+++ b/tests/Unit/Sitemap/SeoMetadataTitleGuesserTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Sitemap;
 
 use Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadata;
+use Symfony\Cmf\Bundle\SeoBundle\SeoPresentation;
 use Symfony\Cmf\Bundle\SeoBundle\Sitemap\SeoMetadataTitleGuesser;
 
 class SeoMetadataTitleGuesserTest extends GuesserTestCase
@@ -29,7 +30,7 @@ class SeoMetadataTitleGuesserTest extends GuesserTestCase
     {
         $seoMetadata = new SeoMetadata();
         $seoMetadata->setTitle('Symfony CMF');
-        $seoPresentation = $this->getMockBuilder('Symfony\Cmf\Bundle\SeoBundle\SeoPresentation')->disableOriginalConstructor()->getMock();
+        $seoPresentation = $this->createMock(SeoPresentation::class);
         $seoPresentation
             ->expects($this->any())
             ->method('getSeoMetadata')

--- a/tests/Unit/Sitemap/SitemapAwareDocumentVoterTest.php
+++ b/tests/Unit/Sitemap/SitemapAwareDocumentVoterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Sitemap;
 
 use Symfony\Cmf\Bundle\SeoBundle\Sitemap\SitemapAwareDocumentVoter;
 use Symfony\Cmf\Bundle\SeoBundle\Sitemap\VoterInterface;
+use Symfony\Cmf\Bundle\SeoBundle\SitemapAwareInterface;
 
 /**
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
@@ -28,7 +29,7 @@ class SitemapAwareDocumentVoterTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->voter = new SitemapAwareDocumentVoter();
-        $this->sitemapAwareDocument = $this->getMock('\Symfony\Cmf\Bundle\SeoBundle\SitemapAwareInterface');
+        $this->sitemapAwareDocument = $this->createMock(SitemapAwareInterface::class);
     }
 
     public function testSitemapAwareDocumentShouldReturnTrueWhenDocumentIsExposed()

--- a/tests/Unit/Sitemap/UrlInformationProviderTest.php
+++ b/tests/Unit/Sitemap/UrlInformationProviderTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\Cmf\Bundle\SeoBundle\Tests\Unit\Sitemap;
 
 use Symfony\Cmf\Bundle\SeoBundle\Model\UrlInformation;
+use Symfony\Cmf\Bundle\SeoBundle\Sitemap\GuesserChain;
+use Symfony\Cmf\Bundle\SeoBundle\Sitemap\LoaderChain;
 use Symfony\Cmf\Bundle\SeoBundle\Sitemap\UrlInformationProvider;
+use Symfony\Cmf\Bundle\SeoBundle\Sitemap\VoterChain;
 
 /**
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
@@ -29,7 +32,7 @@ class UrlInformationProviderTest extends \PHPUnit_Framework_Testcase
         $accepted = new TestModel('accepted');
         $refused = new TestModel('refused');
 
-        $loader = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Sitemap\LoaderChain');
+        $loader = $this->createMock(LoaderChain::class);
         $loader
             ->expects($this->once())
             ->method('load')
@@ -39,7 +42,7 @@ class UrlInformationProviderTest extends \PHPUnit_Framework_Testcase
             )
         ;
 
-        $voter = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Sitemap\VoterChain');
+        $voter = $this->createMock(VoterChain::class);
         $voter
             ->expects($this->at(0))
             ->method('exposeOnSitemap')
@@ -53,12 +56,12 @@ class UrlInformationProviderTest extends \PHPUnit_Framework_Testcase
             ->will($this->returnValue(false))
         ;
 
-        $guesser = $this->getMock('Symfony\Cmf\Bundle\SeoBundle\Sitemap\GuesserChain');
+        $guesser = $this->createMock(GuesserChain::class);
         $guesser
             ->expects($this->once())
             ->method('guessValues')
             ->with(
-                $this->isInstanceOf('Symfony\Cmf\Bundle\SeoBundle\Model\UrlInformation'),
+                $this->isInstanceOf(UrlInformation::class),
                 $this->equalTo($accepted),
                 $this->equalTo('default'))
             ->will($this->returnCallback(function (UrlInformation $info) {


### PR DESCRIPTION
https://github.com/symfony-cmf/routing-bundle/pull/387 reveiled that we had an implicit dependency on the routing bundle for the phpcr-sitemap. this PR moves the setting to an seo bundle config